### PR TITLE
[동현] 게임 맵 최단 거리, 타겟넘버, 여행 경로

### DIFF
--- a/week3/1844/DH.py
+++ b/week3/1844/DH.py
@@ -1,0 +1,32 @@
+from collections import deque
+
+def solution(maps):
+    answer = 0
+    n=len(maps)
+    m = len(maps[0])
+    visited = [[0]*m for i in range(n)]
+    
+    def in_range(x,y):
+        return 0<=x<n and 0<=y<m
+    
+    def bfs(x,y):
+        q = deque()
+        q.append((x,y))
+        visited[x][y] = 1
+        while q:
+            x,y = q.popleft()
+            for i in ((-1,0),(1,0),(0,-1),(0,1)):
+                nx, ny = x+i[0], y+i[1]
+                if not in_range(nx,ny):
+                    continue
+                if visited[nx][ny] == 0 and maps[nx][ny] == 1:
+                    visited[nx][ny] = visited[x][y] + 1
+                    q.append((nx,ny))
+
+        return visited[n-1][m-1]
+
+    answer = bfs(0,0)
+    if answer == 0:
+        return -1
+    else:
+        return answer

--- a/week3/43164/DH.py
+++ b/week3/43164/DH.py
@@ -1,0 +1,26 @@
+answer = []
+def dfs(idx, count, visited, tickets,temp):
+    if count == len(tickets):
+        answer.append(temp)
+        return
+    for i in range(len(tickets)):
+        # 이전 도착지와 출발지가 동일하고 방문한 적이 없는 경우
+        if tickets[i][0] == tickets[idx][1] and visited[i]==0:
+            visited[i] = 1
+            dfs(i, count+1,visited, tickets, temp + [tickets[i][1]])
+            visited[i] = 0
+
+
+            
+def solution(tickets):
+    tickets = sorted(tickets, key = lambda x:(x[0],x[1]))
+    start = 'ICN'
+    for i in range(len(tickets)):
+        visited = [0] * len(tickets)
+        if tickets[i][0] == start:
+            visited[i] = 1
+            temp = ["ICN", tickets[i][1]]
+            count = 1
+            dfs(i, count, visited, tickets, temp)
+    
+    return answer[:][0]

--- a/week3/43165/DH.py
+++ b/week3/43165/DH.py
@@ -1,0 +1,13 @@
+def solution(numbers, target):
+    answer = 0
+    def dfs(idx, number):
+        if idx == len(numbers) and target == number:
+            nonlocal answer 
+            answer += 1
+        elif idx == len(numbers):
+            return
+        else:
+            dfs(idx+1, number + numbers[idx])
+            dfs(idx+1, number - numbers[idx])
+    dfs(0,0)     
+    return answer


### PR DESCRIPTION
## 게임 맵 최단 거리
1. visited 리스트 생성
2. 0,0인 스타트 지점부터 bfs 탐색
3. 만약 맵 범위를 벗어난 경우 continue
4. 만약 이미 방문했거나 길이 아닌 경우: pass
5. 모든 조건을 만족하는 경우 visited[x][y]에 1을 더한 값을 visited[nx][ny]에 저장
6. 큐에 nx,ny를 저장한 뒤 while문 반복
7. 리턴 값을 visited[n-1(행)][m-1(열)] 로 받아 만약 0 이면 -1을 리턴

## 타겟넘버
1. dfs로 idx(=depth)가 맥시멈인 len(numbers)와 일치하고 target과 동일하다면 answer 1 추가
2. dfs 내부 로직은 idx와 numbers[idx]를 + 와 - 를 한 재귀로 완전 탐색같이 진행

## 여행 경로
1. 알파벳 순서에 맞게 sort tickets sorting
2. start를 "ICN"으로 설정한 뒤 ICN에서 시작하는 아이들을 모두 순회
3. dfs 내에서 만약 이전 도착지와 다음 출발지가 동일하고 방문하지 않은 경우: temp에 다음 목적지를 추가한 뒤 dfs 순회
4. 만약 카운트가 총 도시의 수와 같다면 return

### 문제 사항
-> 해당 방식으로 문제를 풀던 중 1번 테스트 케이스에서 막혀 다음 블로그 참조
[https://ckd2806.tistory.com/entry/%ED%8C%8C%EC%9D%B4%EC%8D%AC-python%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%A8%B8%EC%8A%A4-%EC%97%AC%ED%96%89%EA%B2%BD%EB%A1%9C-%EC%BD%94%EB%93%9C-%ED%92%80%EC%9D%B4-%EB%81%84%EC%A0%81%EB%81%84%EC%A0%81](url)