### PR TITLE
[민아] 게임 맵 최단거리, 타겟 넘버, 여행 경로

### DIFF
--- a/week3/1844/이민아.py
+++ b/week3/1844/이민아.py
@@ -1,0 +1,36 @@
+from collections import deque
+def solution(maps):
+    #0.
+    n = len(maps)
+    m = len(maps[0])
+    #1.상좌하우
+    nr = [-1,0,1,0]
+    nc = [0,-1,0,1]
+    def bfs(r,c):
+        queue = deque()
+        queue.append((r,c))
+        while queue:
+            r,c = queue.popleft()
+            for i in range(4):
+                nnr = r + nr[i]
+                nnc = c + nc[i]
+                #3.
+                #범위를 벗어나면 못가
+                if nnr < 0 or nnr >= n or nnc < 0 or nnc >= m:
+                    continue
+                #벽이면 못가
+                if maps[nnr][nnc] == 0:
+                    continue
+                #4.
+                if maps[nnr][nnc] == 1:
+                    queue.append((nnr,nnc))
+                    #방문처리 + 갱신하기
+                    maps[nnr][nnc] = maps[r][c] + 1
+    #bfs 실행
+    bfs(0,0)
+    answer = maps[len(maps)-1][len(maps[0])-1]
+
+    if answer == 1: #도달할 수 없는 경우
+        answer = -1
+
+    return answer          

--- a/week3/43164/이민아.py
+++ b/week3/43164/이민아.py
@@ -1,0 +1,25 @@
+from collections import defaultdict
+def solution(tickets):
+    answer = []
+    #1.
+    tickets.sort(key = lambda x : (x[0],x[1]))
+    
+    #2.
+    loc_dict = defaultdict(list)
+    for s, e in tickets:
+        loc_dict[s].append(e)
+    
+    #3.
+    route = ["ICN"]
+
+    #4
+    while route:
+        loc = route[-1] #현재 위치 : route의 맨 마지막 원소
+        #4-1.
+        if loc not in loc_dict or len(loc_dict[loc]) == 0:
+            answer.append(route.pop())
+        #4-2.
+        else:
+            route.append(loc_dict[loc].pop(0))
+    
+    return answer[::-1]

--- a/week3/43165/이민아.py
+++ b/week3/43165/이민아.py
@@ -1,0 +1,15 @@
+answer = 0
+def dfs(i, cnt, numbers, target):
+    global answer
+    if (i==len(numbers)):
+        if cnt==target:
+            answer+=1
+        return
+    dfs(i+1, cnt+numbers[i], numbers, target)    
+    dfs(i+1, cnt-numbers[i], numbers, target)
+    return
+
+def solution(numbers, target):
+    global answer
+    dfs(0, 0, numbers, target)
+    return answer


### PR DESCRIPTION
# 게임 맵 최단거리
## 접근
아이디어 : 최단거리 -> bfs, (while문, deque)

1. n,m 정의
2. 상하좌우
3. 가지 못하는 상황 정리
4. 갈 수 있는 상황 정리
5. 더해진 최종 수를 답으로 처리

# 타겟 넘버
## 접근
1. i가 numbers길이랑 같고 cnt가 target이랑 같다면 ans +1
2. i+1, i-1 경우 모두 dfs

# 여행 경로
## 접근
1. tickets를 알파벳 순으로 정렬
2. 출발지, 도착지 담은 dict 생성
3. route : 저장할 루트, 항상 ICN에서 시작
4. route가 없어질 때 까지 반복
4-1. 끝나는 경우 : loc_dict에 키가 없거나(맨 마지막 루트인 경우), value를 다 사용한 경우
4-2. 진행되는 경우 : 마지막 루트가 아님 + value가 남아있음