### PR TITLE
[다연] 하노이의 탑, 더 맵게, 배달, 이중우선순위큐, 순위, Minimum Path Sum, Network Delay Time

### DIFF
--- a/week7/12946/dayeon_ku.py
+++ b/week7/12946/dayeon_ku.py
@@ -1,0 +1,14 @@
+def hanoi(x, start, to, mid, answer):
+    if x == 1:
+        return answer.append([start, to])
+    
+    hanoi(x-1, start, mid, to, answer)
+    answer.append([start, to])
+    hanoi(x-1, mid, to, start, answer)
+    
+def solution(n):
+    answer = []
+    
+    hanoi(n, 1, 3, 2, answer)
+    
+    return answer

--- a/week7/12978/dayeon_ku.py
+++ b/week7/12978/dayeon_ku.py
@@ -1,0 +1,37 @@
+# 다익스트라 사용
+import heapq
+
+def solution(N, road, K):
+    INF = int(1e9)
+    
+    start = 1
+    graph = [[] for _ in range(N + 1)]
+    distance = [INF] * (N + 1)
+    distance[start] = 0
+    
+    for a, b, cost in road:
+        graph[a].append((b, cost))
+        graph[b].append((a, cost)) # 양방향이기 때문에
+    
+    def dijkstra(start):
+        q = []
+
+        heapq.heappush(q, (0, start))
+        distance[start] = 0
+        while q:
+            dist, now = heapq.heappop(q)
+
+            if distance[now] < dist:
+                continue
+
+            for b, c in graph[now]:
+                new_cost = dist + c
+
+                if new_cost < distance[b]:
+                    distance[b] = new_cost
+                    heapq.heappush(q, (new_cost, b))
+    
+    
+    dijkstra(start)
+
+    return len(list(filter(lambda x: x <= K, distance)))

--- a/week7/42626/dayeon_ku.py
+++ b/week7/42626/dayeon_ku.py
@@ -1,0 +1,23 @@
+import heapq
+
+def solution(scoville, K):
+    answer = 0
+    heapq.heapify(scoville)
+
+    while scoville[0] < K:
+        if len(scoville) == 0:
+            return answer
+
+        f = heapq.heappop(scoville)
+        
+        try:
+            if f < K:            
+                s = heapq.heappop(scoville)
+                mixed = f + (s * 2)
+
+                heapq.heappush(scoville, mixed)
+                answer += 1
+        except:
+            return -1
+        
+    return answer

--- a/week7/42628/dayeon_ku.py
+++ b/week7/42628/dayeon_ku.py
@@ -1,0 +1,26 @@
+import heapq
+
+def solution(operations):    
+    h = []
+    heapq.heapify(h)
+    
+    for oper in operations:
+        o, num = oper.split()
+        
+        if o == "I":
+            heapq.heappush(h, int(num))
+        else:
+            try:
+                if num == "1":
+                    h.pop()
+                else:
+                    heapq.heappop(h)
+            except:
+                pass
+    
+    if h:
+        # heap의 마지막 값은 꼭 최대값이 아니기 때문에 sort를 해주던지, min() max() 함수를 사용해야 함
+        return [max(h), min(h)]
+    else:
+        return [0, 0]
+    

--- a/week7/49191/dayeon_ku.py
+++ b/week7/49191/dayeon_ku.py
@@ -1,0 +1,32 @@
+# 위상 정렬 구현해봤다가 정렬만 해주고 경기에 대한 정보는 얻을 수 없었어서 폐기
+# 플로이드 워셜
+def solution(n, results):
+    rank = [[0] * (n + 1) for _ in range(n + 1)]
+    
+    for a, b in results:
+        rank[a][b] = 1 # a가 b한테 이김
+        rank[b][a] = -1 # b가 a한테 짐
+        
+    for i in range(n + 1): # 경유
+        for j in range(n + 1): # 시작
+            for k in range(n + 1): # 끝
+                if j == k:
+                    continue
+                
+                # j가 i를 이기고 i가 k를 이김 -> j가 k를 이김
+                if rank[j][i] == 1 and rank [i][k] == 1:
+                    rank[j][k] = 1 # 이김
+                    rank[k][j], rank[k][i], rank[i][j] = -1, -1, -1 # 짐
+                    
+    rankable = 0
+    
+    # 순위가 매겨지려면 n - 1번의 경기를 수행했어야 함
+    # 0이 1개면 n - 1번의 경기를 했다는 의미 -> 정확한 순위를 알 수 있다
+    # index와 선수의 숫자를 맞추기 위해 0번째 index는 사용하지 않았기 때문에 r.count(0) == 2 로 함
+    for r in rank:
+        if r.count(0) == 2:
+            rankable += 1
+    
+    return rankable
+    
+                    

--- a/week7/leet64/dayeon_ku.py
+++ b/week7/leet64/dayeon_ku.py
@@ -1,0 +1,15 @@
+class Solution:
+    def minPathSum(self, grid: List[List[int]]) -> int:
+        m, n = len(grid), len(grid[0])
+
+        for j in range(1, m):
+            grid[j][0] += grid[j - 1][0]
+
+        for i in range(1, n):
+            grid[0][i] += grid[0][i - 1]
+
+        for i in range(1, m):
+            for j in range(1, n):
+                grid[i][j] += min(grid[i - 1][j], grid[i][j - 1])
+
+        return grid[-1][-1]

--- a/week7/leet743/dayeon_ku.py
+++ b/week7/leet743/dayeon_ku.py
@@ -1,0 +1,42 @@
+# sends the signal simulataneously
+import heapq
+
+class Solution:
+    def dijkstra(self, start, distance, graph):
+        q = []
+
+        heapq.heappush(q, (0, start))
+        distance[start] = 0
+
+        while q:
+            dist, now = heapq.heappop(q)
+
+            if distance[now] < dist:
+                continue
+
+            for i in graph[now]:
+                cost = dist + i[1]
+
+                if cost < distance[i[0]]:
+                    distance[i[0]] = cost
+                    heapq.heappush(q, (cost, i[0]))
+
+
+    def networkDelayTime(self, times: List[List[int]], n: int, k: int) -> int:
+        INF = int(1e9)
+        m = len(times)
+
+        graph = [[] for i in range(n + 1)]
+        distance = [INF] * (n + 1)
+
+        for u, v, w in times:
+            graph[u].append((v, w))
+
+        self.dijkstra(k, distance, graph)
+
+        result = distance[1:]
+
+        if sum(d == INF for d in result) > 0:
+            return -1
+        else:
+            return max(result)


### PR DESCRIPTION
# 접근
## 하노이 탑
하노이 탑에 또 졌습니다.. 이번엔 진짜 이기고 싶었는데 졌어요..
[이 블로그](https://m.blog.naver.com/jaeyoon_95/221762231876) 참고 했고 재귀로 풀었습니다
혹시 위 블로그에 yield로 푸는 부분이 이해가 안되는데 혹시 이해 가시는 분 설명 해주시면 감사하겠습니다 ((

## 더 맵게
1. scoville을 heapify 해줌
2. scoville의 가장 작은 수가 K보다 작은 동안 while을 돌려줌
3. 만약 스코빌이 비었다면 answer 반환
4. 가장 안 매운 값(f) pop해주기
5. 만약 f가 K보다 작다면 두번째로 안 매운 값 뽑고 수식 적용
6. 믹스해서 다시 heap에 넣어주기
7. 만약 index out of range 에러가 뜬다면 -1 반환 (마지막 값이 K보다 작기 때문에)

## 배달
그래프라서 가장 최근에 배운 크루스칼을 적용해보려고 했지만 답을 구하지 못해서 블로그를 찾아보니 다익스트라로 푸는 문제더라고요,, 그래서 다익스트라로 풀어왔습니다
다익스트라 소스코드와 유일하게 다른 부분은 양방향 edge이기 때문에 a->b, b->a 모두 graph에 담아둔다는 부분입니다!

## 이중우선순위큐
heap 사용해서 풀었습니다!
1. 요소를 제거해주는 부분에서 try-except를 사용해 리스트가 비어있다면 해단 커맨드는 패스하도록 해줬습니다! (요즘 try-except 남발하는 거 같아서 혹시 저거 말고 다른 깔쌈한 방법 아시는 분 계시면 코멘트 남겨주세요,,)
2. heap의 마지막 요소는 무조건 max값이 나오는 게 아니기 때문에 max() min() built-in 함수를 사용해 return 해주었습니다

## 순위
위상 정렬을 사용하면 순위를 알 수 있을 거 같다고 생각해 구현해봤는데, 대략적인 순위는 알 수 있었지만 경기에 대한 정보는 얻을 수 없어서 블로그를 찾아봤습니다. 플로이드 워셜을 사용하면 구현할 수 있다고 해서 구현해보려 했지만,, 실패하고 [블로그 코드](https://velog.io/@49crehbgr/%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%A8%B8%EC%8A%A4Lv.3-%EC%88%9C%EC%9C%84)를 사용했습니다.. ^^

## Minimum Path Sum
DP 사용했습니다
1. 1행, 1열 먼저 처리해줌
2. min()으로 왼쪽에서 오는 방법과 위에서 오는 방법의 비용을 비교함
3. 가장 마지막 노드의 값을 반환

## Network Delay Time
다익스트라 사용했습니다. 다익스트라 소스 코드랑 다 똑같고, 유일하게 다른 부분은 반환해주는 부분입니다. 만약 result 리스트에 하나라도 INF 값을 가진다면 갈 수 없는 노드가 있다는 뜻이라 -1을 반환하게 하고, 아니라면 distance 중 max인 값을 반환하도록 했습니다.